### PR TITLE
Intercept and redirect new users to /Account/UpdateAccount

### DIFF
--- a/src/FurCoNZ.Web/Auth/NzFursOpenIdConnectEvents.cs
+++ b/src/FurCoNZ.Web/Auth/NzFursOpenIdConnectEvents.cs
@@ -24,10 +24,9 @@ namespace FurCoNZ.Web.Auth
             var identity = (ClaimsIdentity)context.Principal.Identity;
             var user = await userService.GetUserFromIssuerAsync(context.Principal.FindFirst("iss").Value, context.Principal.FindFirst("sub").Value, context.HttpContext.RequestAborted);
 
-            // User already exists,m nothing to do?
+            // Create a new user if they do not exist locally fill and in the defaults. 
             if (user == null)
             {
-                // Create a new user, fill it in with defaults. 
                 user = new User
                 {
                     Name = context.User.Value<string>("name"),
@@ -45,10 +44,11 @@ namespace FurCoNZ.Web.Auth
 
                 await userService.CreateUserAsync(user);
 
+                // Give new uers a chance to update their details
                 // 1. Save redirect URL to session
                 context.HttpContext.Session.Set(AccountController.RedirectAfterDetailsSessionKey, context.Properties.RedirectUri);
                 // 2. Show firtst time page asking for name, details etc,
-                context.Properties.RedirectUri = linkGenerator.GetUriByAction(context.HttpContext, nameof(AccountController.UpdateAccount), "Account");
+                context.Properties.RedirectUri = linkGenerator.GetUriByAction(context.HttpContext, nameof(AccountController.Index), "Account");
                 // 3. if skipped or accepted, redirect to initial redirect page (See AccountController.UpdateAccount)
             }
 

--- a/src/FurCoNZ.Web/Startup.cs
+++ b/src/FurCoNZ.Web/Startup.cs
@@ -267,11 +267,11 @@ namespace FurCoNZ.Web
             }
             app.UseForwardedHeaders(forwardedHeaderOptions);
 
+            app.UseSession();
             app.UseAuthentication();
             app.UseHttpsRedirection();
             app.UseStaticFiles();
             app.UseCookiePolicy();
-            app.UseSession();
 
             app.UseMvc(routes =>
             {

--- a/src/FurCoNZ.Web/ViewModels/AccountViewModel.cs
+++ b/src/FurCoNZ.Web/ViewModels/AccountViewModel.cs
@@ -17,6 +17,8 @@ namespace FurCoNZ.Web.ViewModels
             Email = user.Email;
         }
 
+        public bool IsConfirmingDetails { get; set; }
+
         [Required]
         public string Name { get; set; }
 

--- a/src/FurCoNZ.Web/Views/Account/Index.cshtml
+++ b/src/FurCoNZ.Web/Views/Account/Index.cshtml
@@ -8,6 +8,13 @@
     <div class="card-body">
         <h5 class="card-title">Your Account</h5>
 
+        @if (Model.IsConfirmingDetails)
+        {
+            <div class="alert alert-primary" role="alert">
+                Welcome! Please confirm your name and email and click Continue below!
+            </div>
+        }
+
         <form method="post" asp-action="UpdateAccount">
             <div class="form-group">
                 <label for="Name">Prefered Called Name</label>
@@ -19,7 +26,9 @@
                 <input asp-for="Email" class="form-control" aria-describedby="EmailHelp" placeholder="burb@furry.nz">
                 <small id="EmailHelp" class="form-text text-muted">We'll never share your email with anyone else.</small>
             </div>
-            <button type="submit" class="btn btn-primary">Update</button>
+            <button type="submit" class="btn btn-primary">
+                @(Model.IsConfirmingDetails ? "Continue" : "Update")
+            </button>
         </form>
     </div>
 </div>

--- a/src/FurCoNZ.Web/Views/Account/Index.cshtml
+++ b/src/FurCoNZ.Web/Views/Account/Index.cshtml
@@ -15,7 +15,7 @@
             </div>
         }
 
-        <form method="post" asp-action="UpdateAccount">
+        <form asp-controller="Account" asp-action="UpdateAccount" method="post">
             <div class="form-group">
                 <label for="Name">Prefered Called Name</label>
                 <input asp-for="Name" class="form-control" aria-describedby="NameHelp" placeholder="Alex Bird-Person">


### PR DESCRIPTION
To help ensure we have the current user's details correct, intercept first time login requests to `/Account/UpdateAccount`. They may click `Continue` to return to their original destination with the opportunity to change any details 