### PR TITLE
Add border-bottom to active nav bar items

### DIFF
--- a/src/FurCoNZ.Web/FrontEnd/scss/_site.scss
+++ b/src/FurCoNZ.Web/FrontEnd/scss/_site.scss
@@ -7,6 +7,10 @@ a.navbar-brand {
   word-break: break-all;
 }
 
+.nav-link.active {
+    @extend .border-bottom
+}
+
 /* Sticky footer styles
 -------------------------------------------------- */
 html {

--- a/src/FurCoNZ.Web/Views/Shared/_Layout.cshtml
+++ b/src/FurCoNZ.Web/Views/Shared/_Layout.cshtml
@@ -19,16 +19,16 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index">Home</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Index" asp-active-controllers="Home" asp-active-actions="Index">Home</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy" asp-active-controllers="Home" asp-active-actions="Privacy">Privacy</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Account" asp-action="Index">Account</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Account" asp-action="Index" asp-active-controllers="Account">Account</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-area="" asp-controller="Order" asp-action="Index">Order</a>
+                            <a class="nav-link text-dark" asp-area="" asp-controller="Order" asp-action="Index" asp-active-controllers="Order">Order</a>
                         </li>
                         <li class="nav-item" asp-authorize asp-policy="AdminOnly">
                             <a class="nav-link text-dark" asp-area="admin" asp-controller="Home" asp-action="Index">Admin</a>


### PR DESCRIPTION
The site wide navigation bar now has an `.active` class applied to the nav items when it's active. 

I've added an example border bottom effect when the link is active
![image](https://user-images.githubusercontent.com/1032029/63845143-99fd9900-c9dd-11e9-9a2b-1b54c15025fa.png)
