### PR TITLE
Modify Azure Pipeline for testing and release

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,6 +5,7 @@
 
 trigger:
 - master
+- release
 
 pool:
   vmImage: 'Ubuntu-16.04'
@@ -12,12 +13,18 @@ pool:
 variables:
   dockerId: nzfurs
   imageName: 'furconz'
+  isPullRequest: eq(variables['Build.Reason'], 'PullRequest')
 
 steps:
 - script: |
     docker build -f Dockerfile -t $(dockerId)/$(imageName):$(build.buildId) -t $(dockerId)/$(imageName):latest .
-  displayName: 'docker build'
+  displayName: Build Docker Container
+- script: |
+    docker tag $(dockerId)/$(imageName):$(build.buildId) $(dockerId)/$(imageName):stable
+  condition: in(variables['Build.SourceBranch'], 'refs/heads/release')
+  displayName: Tag release image with :stable
 - script: |
     docker login -u $(dockerHubId) -p $(dockerHubPassword)
     docker push $(dockerId)/$(imageName)
-  displayName: 'docker push'
+  condition: not(${{ variables.isPullRequest }})
+  displayName: Publish to Docker Hub


### PR DESCRIPTION
The intention of this change is to 

- Pull Requests will only be built, but not published to Docker Hub
- `master` branch builds will publish to Docker hub
  - **To do:** Deploy to testing server
- `release` branch will be tagged `:stable` and published to Docker Hub
  - **To do:**  Deploy to production server