### PR TITLE
Added detail to Parental Consent page

### DIFF
--- a/src/FurCoNZ.Web/Views/Home/ParentalConsent.cshtml
+++ b/src/FurCoNZ.Web/Views/Home/ParentalConsent.cshtml
@@ -5,5 +5,26 @@
 <h1>Parental Consent Form</h1>
 
 <p>
+    For unaccompanied attendees under the age of 18, consent from a Parent or Legal Guardian* is <b>mandatory</b>.
+	The Parental Consent forms outlines the following:
+</p>
+<ul>
+	<li>Emergency contact information</li>
+	<li>Emergency medical information</li>
+	<li>FurCoNZ Staff responsibility and liability</li>
+	<li>Attendee responsibility and liability</li>
+	<li>Parent responsibility and liability</li>
+	<li>Authorisation to act in emergency situations</li>
+</ul>
+<p>
     Download the <a href="/assets/FurCoNZ-Parental_Consent_Form-2020.pdf">Parental Consent Form</a>
 </p>
+<p>
+	Completed Parental Consent Forms for Full Event attendees must be received <u>no later than the 16th January 2020</u>. Completed Parental Consent Forms for Day Pass attendees may be presented on the day, but the Parent or Legal Guardian must be present for verification.
+</p>
+<p>
+	*Legal Guardians are guardians who have been appointed by a Family Court or a guardian that has been appointed by a Will (or other Legal Document). Other related adults or non-legal guardians cannot not be accepted. If there is concern, FurCoNZ may ask to seek verification of this.
+</p>
+<p>
+	<i>If you are a minor, and your situation falls outside our requirements (eg. if you are a legally emancipated minor), contact FurCoNZ staff to discuss your options before starting the registration process.</i>
+</p>	


### PR DESCRIPTION
Previous page had no detail whatsoever.
More detail on what the Parental consent is, and due dates for Consent forms.